### PR TITLE
Re-add "invalid" modifier for explicit form errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ module.exports = {
   ],
   darkMode: "class",
   plugins: [
-+    # Enables more explicit form error styling.
++    # Enables explicit form error styling.
 +    plugin(function({ addVariant }) {
 +      addVariant('invalid', '&.invalid:not(.phx-no-feedback)')
 +    })

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Documentation can be found at [https://hexdocs.pm/phoenix_ui](https://hexdocs.pm
 Add a new path pattern to `assets/tailwind.config.js` so Tailwind can import and utilize Phoenix UI css classes:
 
 ```diff
++const plugin = require('tailwindcss/plugin')
+
 module.exports = {
   content: [
     './js/**/*.js',
@@ -39,7 +41,12 @@ module.exports = {
 +    "../deps/phoenix_ui/**/*.*ex",
   ],
   darkMode: "class",
-  plugins: [],
+  plugins: [
++    # Enables more explicit form error styling.
++    plugin(function({ addVariant }) {
++      addVariant('invalid', '&.invalid:not(.phx-no-feedback)')
++    })
+  ],
   theme: {
     extend: {},
   },

--- a/lib/phoenix_ui/components/button.ex
+++ b/lib/phoenix_ui/components/button.ex
@@ -2,8 +2,6 @@ defmodule PhoenixUI.Components.Button do
   @moduledoc """
   Provides button component.
   """
-  import PhoenixUI.Components.Element
-
   use PhoenixUI, :component
 
   @default_color "blue"
@@ -40,9 +38,9 @@ defmodule PhoenixUI.Components.Button do
       |> build_btn_attrs()
 
     ~H"""
-    <.element {@btn_attrs}>
+    <.dynamic_tag {@btn_attrs}>
       <%= render_slot(@inner_block) %>
-    </.element>
+    </.dynamic_tag>
     """
   end
 
@@ -83,7 +81,7 @@ defmodule PhoenixUI.Components.Button do
       assigns
       |> assigns_to_attributes([:color, :element, :extend_class, :size, :square, :variant])
       |> Keyword.put_new(:class, class)
-      |> Keyword.put_new(:variant, assigns[:element])
+      |> Keyword.put_new(:name, assigns[:element])
 
     assign(assigns, :btn_attrs, attrs)
   end

--- a/lib/phoenix_ui/components/checkbox.ex
+++ b/lib/phoenix_ui/components/checkbox.ex
@@ -71,7 +71,24 @@ defmodule PhoenixUI.Components.Checkbox do
   end
 
   defp build_checkbox_attrs(assigns) do
-    class = build_class(~w(checkbox mr-2 #{Map.get(assigns, :extend_class)}))
+    class = build_class(~w(
+      appearance-none
+      h-5 w-5 border
+      border-slate-500
+      checked:border-blue-500
+      hover:bg-slate-500
+      cursor-pointer
+      transition-all ease-in-out duration-300
+      after:content-['']
+      after:border-2
+      after:border-white
+      after:rotate-45
+      after:absolute
+      after:w-[5px]
+      after:h-[10px]
+      mr-2
+      #{Map.get(assigns, :extend_class)}
+    ))
 
     attrs =
       assigns

--- a/lib/phoenix_ui/components/collapse.ex
+++ b/lib/phoenix_ui/components/collapse.ex
@@ -116,7 +116,13 @@ defmodule PhoenixUI.Components.Collapse do
 
     attrs =
       assigns
-      |> assigns_to_attributes([:element, :max_size, :extend_class, :orientation])
+      |> assigns_to_attributes([
+        :element,
+        :max_size,
+        :extend_class,
+        :orientation,
+        :transition_duration
+      ])
       |> Keyword.put_new(:class, class)
       |> Keyword.put(:variant, assigns[:element])
 

--- a/lib/phoenix_ui/components/label.ex
+++ b/lib/phoenix_ui/components/label.ex
@@ -62,10 +62,14 @@ defmodule PhoenixUI.Components.Label do
     attrs =
       assigns
       |> assigns_to_attributes([:extend_class, :field, :form, :invalid?, :margin])
+      |> Keyword.put_new(:phx_feedback_for, phx_feedback_for(assigns))
       |> Keyword.put_new(:class, class)
 
     assign(assigns, :label_attrs, attrs)
   end
+
+  defp phx_feedback_for(%{field: field, form: form}), do: input_name(form, field)
+  defp phx_feedback_for(_assigns), do: nil
 
   ### CSS Classes ##########################
 

--- a/lib/phoenix_ui/components/label.ex
+++ b/lib/phoenix_ui/components/label.ex
@@ -54,6 +54,7 @@ defmodule PhoenixUI.Components.Label do
     class = build_class(~w(
       label flex items-center
       #{classes(:color, assigns)}
+      #{classes(:invalid, assigns)}
       #{classes(:margin, assigns)}
       #{Map.get(assigns, :extend_class)}
     ))
@@ -69,11 +70,12 @@ defmodule PhoenixUI.Components.Label do
   ### CSS Classes ##########################
 
   # Color
-  defp classes(:color, %{invalid?: true}), do: "text-red-500"
-
   defp classes(:color, _assigns) do
-    "text-slate-600 dark:text-slate-300 disabled:text-slate-500 dark:disabled:text-slate-400 invalid:text-red-500"
+    "text-slate-600 dark:text-slate-300 disabled:text-slate-500 dark:disabled:text-slate-400 dark:invalid:text-red-500 invalid:text-red-500"
   end
+
+  # Invalid
+  defp classes(:invalid, %{invalid?: true}), do: "invalid"
 
   # Margin
   defp classes(:margin, %{margin: true}), do: "mb-2"

--- a/lib/phoenix_ui/components/list.ex
+++ b/lib/phoenix_ui/components/list.ex
@@ -86,7 +86,7 @@ defmodule PhoenixUI.Components.List do
 
   defp build_list_attrs(assigns) do
     extend_class = build_class(~w(
-      py-1
+      list py-1
       #{Map.get(assigns, :extend_class)}
     ))
 

--- a/lib/phoenix_ui/components/text_input.ex
+++ b/lib/phoenix_ui/components/text_input.ex
@@ -39,10 +39,20 @@ defmodule PhoenixUI.Components.TextInput do
     ~H"""
     <.form_group extend_class={assigns[:extend_class]}>
       <%= if assigns[:form] && assigns[:label] == nil do %>
-        <.label field={assigns[:field]} form={assigns[:form]}/>
+        <.label
+          field={@field}
+          form={@form}
+          phx_feedback_for={Phoenix.HTML.Form.input_name(@form, @field)}
+          invalid?={assigns[:invalid?]}
+        />
       <% end %>
       <%= if assigns[:form] && assigns[:label] do %>
-        <.label field={assigns[:field]} form={assigns[:form]}>
+        <.label
+          field={@field}
+          form={@form}
+          phx_feedback_for={Phoenix.HTML.Form.input_name(@form, @field)}
+          invalid?={assigns[:invalid?]}
+        >
           <%= @label %>
         </.label>
       <% end %>
@@ -83,6 +93,7 @@ defmodule PhoenixUI.Components.TextInput do
       placeholder-slate-400 dark:placeholder-slate-400 transition-all ease-in-out duration-200
       #{classes(:background, assigns)}
       #{classes(:end_icon, assigns)}
+      #{classes(:invalid, assigns)}
       #{classes(:rounded, assigns)}
       #{classes(:start_icon, assigns)}
       #{classes(:variant, assigns)}
@@ -146,6 +157,9 @@ defmodule PhoenixUI.Components.TextInput do
   defp classes(:end_icon, %{end_icon: _}), do: "pr-12"
   defp classes(:end_icon, _assigns), do: "pr-3"
 
+  # Invalid
+  defp classes(:invalid, %{invalid?: true}), do: "invalid"
+
   # Rounded
   defp classes(:rounded, %{variant: "underline"}), do: nil
   defp classes(:rounded, %{variant: "unstyled"}), do: nil
@@ -157,7 +171,10 @@ defmodule PhoenixUI.Components.TextInput do
 
   # Variant - Simple
   defp classes(:variant, %{variant: "simple"}) do
-    "border border-slate-300 shadow-sm focus:border-blue-300 focus:ring focus:ring-opacity-50 focus:ring-blue-200"
+    """
+    border border-slate-300 shadow-sm focus:border-blue-300 focus:ring focus:ring-opacity-50 focus:ring-blue-200
+    invalid:border-red-500 invalid:focus:border-red-300 invalid:focus:ring-red-200
+    """
   end
 
   # Variant - Solid

--- a/lib/phoenix_ui/components/text_input.ex
+++ b/lib/phoenix_ui/components/text_input.ex
@@ -39,20 +39,10 @@ defmodule PhoenixUI.Components.TextInput do
     ~H"""
     <.form_group extend_class={assigns[:extend_class]}>
       <%= if assigns[:form] && assigns[:label] == nil do %>
-        <.label
-          field={@field}
-          form={@form}
-          phx_feedback_for={Phoenix.HTML.Form.input_name(@form, @field)}
-          invalid?={assigns[:invalid?]}
-        />
+        <.label field={@field} form={@form} invalid?={assigns[:invalid?]}/>
       <% end %>
       <%= if assigns[:form] && assigns[:label] do %>
-        <.label
-          field={@field}
-          form={@form}
-          phx_feedback_for={Phoenix.HTML.Form.input_name(@form, @field)}
-          invalid?={assigns[:invalid?]}
-        >
+        <.label field={@field} form={@form} invalid?={assigns[:invalid?]}>
           <%= @label %>
         </.label>
       <% end %>
@@ -173,23 +163,26 @@ defmodule PhoenixUI.Components.TextInput do
   defp classes(:variant, %{variant: "simple"}) do
     """
     border border-slate-300 shadow-sm focus:border-blue-300 focus:ring focus:ring-opacity-50 focus:ring-blue-200
-    invalid:border-red-500 invalid:focus:border-red-300 invalid:focus:ring-red-200
+    invalid:border-red-500 invalid:focus:border-red-300 invalid:focus:ring-red-300
     """
   end
 
   # Variant - Solid
   defp classes(:variant, %{variant: "solid"}) do
-    "shadow-sm border border-transparent focus:border-slate-500"
+    "shadow-sm border border-transparent focus:border-slate-500 invalid:border-red-500"
   end
 
   # Variant - Underline
   defp classes(:variant, %{variant: "underline"}) do
-    "border-b-2 border-slate-300 shadow-sm focus:border-slate-600"
+    "border-b-2 border-slate-300 shadow-sm focus:border-slate-600 invalid:border-red-300 invalid:focus:border-red-600"
   end
 
   # Variant - Unstyled
   defp classes(:variant, %{variant: "unstyled"}) do
-    "border border-slate-300 shadow-sm ring-0 focus:ring-1 focus:ring-blue-500 focus:border-blue-500"
+    """
+    border border-slate-300 shadow-sm ring-0 focus:ring-1 focus:ring-blue-500 focus:border-blue-500
+    invalid:border-red-300 invalid:focus:ring-red-500 invalid:focus:border-red-500
+    """
   end
 
   # Width

--- a/lib/phoenix_ui/components/typography.ex
+++ b/lib/phoenix_ui/components/typography.ex
@@ -2,8 +2,6 @@ defmodule PhoenixUI.Components.Typography do
   @moduledoc """
   Provides typography component.
   """
-  import PhoenixUI.Components.Element
-
   use PhoenixUI, :component
 
   @default_variant "p"
@@ -30,9 +28,9 @@ defmodule PhoenixUI.Components.Typography do
       |> build_typography_attrs()
 
     ~H"""
-    <.element {@typography_attrs}>
+    <.dynamic_tag {@typography_attrs}>
       <%= render_slot(@inner_block) %>
-    </.element>
+    </.dynamic_tag>
     """
   end
 
@@ -57,7 +55,7 @@ defmodule PhoenixUI.Components.Typography do
   ### Typography Attrs ##########################
 
   defp build_typography_attrs(assigns) do
-    variant = assigns[:element] || assigns[:variant]
+    dynamic_tag_name = assigns[:element] || assigns[:variant]
 
     class = build_class(~w(
       typography
@@ -73,7 +71,7 @@ defmodule PhoenixUI.Components.Typography do
       assigns
       |> assigns_to_attributes([:align, :color, :element, :extend_class, :variant])
       |> Keyword.put_new(:class, class)
-      |> Keyword.put(:variant, variant)
+      |> Keyword.put(:name, dynamic_tag_name)
 
     assign(assigns, :typography_attrs, attrs)
   end

--- a/lib/phoenix_ui/helpers.ex
+++ b/lib/phoenix_ui/helpers.ex
@@ -6,6 +6,58 @@ defmodule PhoenixUI.Helpers do
 
   import Phoenix.LiveViewTest
 
+  use Phoenix.Component
+
+  @doc """
+  Generates a dynamically named HTML tag.
+
+  Raises ArgumentError if the tag name is found to be unsafe HTML.
+
+  ## Attributes
+
+    * `:name` - The required  name of the tag, such as: "div"
+
+  All other attributes are added to the generated tag, ensuring
+  proper HTML escaping.
+
+  ## Examples
+
+      <.dynamic_tag name="input" type="text"/>
+      => "<input type="text"/>
+
+      <.dynamic_tag name="p">content</.dynamic_tag>
+      => "<p>content</p>"
+  """
+  def dynamic_tag(%{name: name} = assigns) do
+    rest = assigns_to_attributes(assigns)
+    tag_name = to_string(name)
+
+    tag =
+      case Phoenix.HTML.html_escape(tag_name) do
+        {:safe, ^tag_name} ->
+          tag_name
+
+        {:safe, _escaped} ->
+          raise ArgumentError,
+                "expected dynamic_tag name to be safe HTML, got: #{inspect(tag_name)}"
+      end
+
+    assigns =
+      assigns
+      |> assign(:tag, tag)
+      |> assign(:escaped_attrs, Phoenix.HTML.attributes_escape(rest))
+
+    if Map.has_key?(assigns, :inner_block) do
+      ~H"""
+      <%= {:safe, [?<, @tag]} %><%= @escaped_attrs %><%= {:safe, [?>]} %><%= render_slot(@inner_block) %><%= {:safe, [?<, ?/, @tag, ?>]} %>
+      """
+    else
+      ~H"""
+      <%= {:safe, [?<, @tag]} %><%= @escaped_attrs %><%= {:safe, [?/, ?>]} %>
+      """
+    end
+  end
+
   @doc """
   Builds and normalizes list of classes.
 


### PR DESCRIPTION
Re-adds "invalid" modifier for explicit form errors. E.g., :

```javascript
const plugin = require('tailwindcss/plugin')

module.exports = {
  ...
  plugins: [
    ...
    plugin(function({ addVariant }) {
      addVariant('invalid', '&.invalid:not(.phx-no-feedback)')
    })
  ],
};
```

https://tailwindcss.com/docs/plugins#adding-variants