### PR TITLE
Misc. Cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: PhoenixUI CI
+name: Phoenix.UI CI
 
 on:
   pull_request:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PhoenixUI
+# Phoenix.UI
 
 A complimentary UI library for the Phoenix Framework and Phoenix LiveView.
 
@@ -35,7 +35,7 @@ module.exports = {
     '../lib/*_web.ex',
     '../lib/*_web/**/*.*ex',
 
-+    # Allows PhoenixUI css to be processed by JIT compiler.
++    # Allows Phoenix.UI css to be processed by JIT compiler.
 +    "../deps/phoenix_ui/**/*.*ex",
   ],
   darkMode: "class",
@@ -57,10 +57,10 @@ There are multiple ways to import components. We recommend importing components 
     quote do
       ...
 
-      # PhoenixUI macro which imports all components and JS interactions
-      use PhoenixUI
+      # Phoenix.UI macro which imports all components and JS interactions
+      use Phoenix.UI
       # Or import components individually
-      import PhoenixUI.Components.{Button, Tooltip, ...}
+      import Phoenix.UI.Components.{Button, Tooltip, ...}
 
       ...
     end

--- a/lib/mix/tasks/heroicons/generate.ex
+++ b/lib/mix/tasks/heroicons/generate.ex
@@ -13,11 +13,11 @@ defmodule Mix.Tasks.Heroicons.Generate do
     file = File.open!("lib/phoenix_ui/components/heroicon.ex", [:write])
 
     IO.binwrite(file, """
-    defmodule PhoenixUI.Components.Heroicon do
+    defmodule Phoenix.UI.Components.Heroicon do
       @moduledoc \"\"\"
       Provides heroicon component.
       \"\"\"
-      use PhoenixUI, :component
+      use Phoenix.UI, :component
 
       attr(:color, :string, default: "inherit")
       attr(:name, :string, required: true)

--- a/lib/mix/tasks/tailwind/generate_classes.ex
+++ b/lib/mix/tasks/tailwind/generate_classes.ex
@@ -2,12 +2,12 @@ defmodule Mix.Tasks.Tailwind.GenerateClasses do
   @moduledoc """
   Mix task for generating, parsing, and referencing all Phoenix UI classes.
   """
-  alias PhoenixUI.Theme
+  alias Phoenix.UI.Theme
 
   import Phoenix.{Component, LiveViewTest}
 
   use Mix.Task
-  use PhoenixUI
+  use Phoenix.UI
 
   @impl true
   def run(_args) do
@@ -16,9 +16,9 @@ defmodule Mix.Tasks.Tailwind.GenerateClasses do
     file = File.open!("lib/phoenix_ui/tailwind/generated_classes.ex", [:write])
 
     IO.binwrite(file, """
-    defmodule PhoenixUI.Tailwind.GeneratedClasses do
+    defmodule Phoenix.UI.Tailwind.GeneratedClasses do
       @moduledoc \"\"\"
-      Referential PhoenixUI classes for JIT compilation:
+      Referential Phoenix.UI classes for JIT compilation:
     """)
 
     [

--- a/lib/mix/tasks/tailwind/generate_classes.ex
+++ b/lib/mix/tasks/tailwind/generate_classes.ex
@@ -2,7 +2,12 @@ defmodule Mix.Tasks.Tailwind.GenerateClasses do
   @moduledoc """
   Mix task for generating, parsing, and referencing all Phoenix UI classes.
   """
+  alias PhoenixUI.Theme
+
+  import Phoenix.{Component, LiveViewTest}
+
   use Mix.Task
+  use PhoenixUI
 
   @impl true
   def run(_args) do
@@ -16,11 +21,252 @@ defmodule Mix.Tasks.Tailwind.GenerateClasses do
       Referential PhoenixUI classes for JIT compilation:
     """)
 
-    "lib/phoenix_ui/components/**/*.ex"
-    |> Path.wildcard()
-    |> Enum.map(&convert_path_to_module/1)
-    |> Enum.filter(&generatable?/1)
-    |> Enum.map(& &1.classes())
+    [
+      # Accordion
+      {
+        &accordion/1,
+        [
+          header: [[%{inner_block: fn _, _ -> "header" end}]],
+          id: ["accordion"],
+          open: [true, false],
+          panel: [[%{inner_block: fn _, _ -> "panel" end}]]
+        ]
+      },
+      # Alert
+      {
+        &alert/1,
+        [
+          action: [["phx-click": "lv:clear-flash"]],
+          severity: ["error", "info", "success", "warning"],
+          variant: ["filled", "outlined", "standard"]
+        ]
+      },
+      # AvatarGroup
+      {
+        &avatar_group/1,
+        [
+          avatar: [[%{inner_block: nil}]],
+          color: Theme.colors(),
+          inner_block: [nil, []],
+          size: ["xs", "sm", "md", "lg", "xl"],
+          spacing: ["xs", "sm", "md", "lg", "xl"],
+          variant: ["circular", "rounded", "square"]
+        ]
+      },
+      # Avatar
+      {
+        &avatar/1,
+        [
+          inner_block: [nil, []],
+          color: Theme.colors(),
+          border: [true, false],
+          size: ["xs", "sm", "md", "lg", "xl"] ++ range(0.25, 20, 0.25),
+          variant: ["circular", "rounded", "square"]
+        ]
+      },
+      # Backdrop
+      {
+        &backdrop/1,
+        [
+          invisible: [true, false],
+          open: [true, false],
+          transition_duration: Theme.transition_durations()
+        ]
+      },
+      # Badge
+      {
+        &badge/1,
+        [
+          color: Theme.colors(),
+          content: [""],
+          position: [
+            "bottom_end",
+            "bottom_start",
+            "bottom",
+            "left_end",
+            "left_start",
+            "left",
+            "right_end",
+            "right_start",
+            "right",
+            "top_end",
+            "top_start",
+            "top"
+          ],
+          variant: ["dot", "standard"]
+        ]
+      },
+      # Breadcrumb
+      {
+        &breadcrumbs/1,
+        [
+          a: [
+            [
+              %{inner_block: fn _, _ -> "Phoenix UI" end},
+              %{inner_block: fn _, _ -> "Components" end}
+            ]
+          ]
+        ]
+      },
+      # Button
+      {
+        &button/1,
+        [
+          color: Theme.colors(),
+          disabled: [true, false],
+          size: ["xs", "sm", "md", "lg", "xl"],
+          square: [true, false],
+          variant: ["contained", "icon", "outlined", "text"]
+        ]
+      },
+      # Card
+      {
+        &card/1,
+        [
+          elevation: [0, 1, 2, 3, 4, 5],
+          square: [true, false],
+          variant: ["elevated", "outlined"]
+        ]
+      },
+      # Card Header
+      {&card_header/1, []},
+      # Card Media
+      {&card_media/1, [src: [""]]},
+      # Card Content
+      {&card_content/1, []},
+      # Card Actions
+      {&card_action/1, []},
+      # Chip
+      {
+        &chip/1,
+        [
+          color: Theme.colors(),
+          label: ["label"],
+          on_click: ["handle_click"],
+          on_delete: ["handle_delete"],
+          variant: ["filled", "outlined"]
+        ]
+      },
+      # Collapse
+      {
+        &collapse/1,
+        [
+          max_size: Enum.map(range(100, 5000, 100), &"#{&1}px"),
+          open: [true, false],
+          orientation: ["horizontal", "vertical"],
+          transition_duration: Theme.transition_durations()
+        ]
+      },
+      # Container
+      {
+        &container/1,
+        [
+          max_width: Theme.max_widths(),
+          variant: ["fixed", "fluid"]
+        ]
+      },
+      # Divider
+      {
+        &divider/1,
+        [
+          color: Theme.colors(),
+          variant: ["full_width", "inset", "middle"]
+        ]
+      },
+      # Drawer
+      {
+        &drawer/1,
+        [
+          id: ["drawer"],
+          open: [true, false],
+          variant: [:temporary]
+        ]
+      },
+      # Grid
+      {
+        &grid/1,
+        [
+          column_spacing: 1..12,
+          columns: 1..12,
+          row_spacing: 1..12,
+          spacing: 1..12
+        ]
+      },
+      # Heroicon
+      {
+        &heroicon/1,
+        [
+          color: Theme.colors(),
+          name: ["academic-cap"],
+          size: ["xs", "sm", "md", "lg", "xl"] ++ range(0.25, 20, 0.25),
+          variant: ["outline", "solid"]
+        ]
+      },
+      # Link
+      {
+        &link/1,
+        [
+          color: Theme.colors(),
+          disabled: [false, true]
+        ]
+      },
+      # List
+      {&list/1, []},
+      # List Item
+      {&list_item/1, []},
+      # Modal
+      {
+        &modal/1,
+        [
+          id: ["modal"],
+          max_width: [:xs, :sm, :md, :lg, :xl],
+          open: [true, false]
+        ]
+      },
+      # Paper
+      {
+        &paper/1,
+        [
+          blur: [true, false, "none", "sm", "md", "lg", "xl", "2xl", "3xl"],
+          elevation: [0, 1, 2, 3, 4, 5],
+          square: [true, false],
+          variant: ["elevated", "outlined"]
+        ]
+      },
+      # Tooltip
+      {
+        &tooltip/1,
+        [
+          color: Theme.colors(),
+          content: [""],
+          position: [
+            "bottom_end",
+            "bottom_start",
+            "bottom",
+            "left_end",
+            "left_start",
+            "left",
+            "right_end",
+            "right_start",
+            "right",
+            "top_end",
+            "top_start",
+            "top"
+          ],
+          variant: ["arrow", "simple"]
+        ]
+      },
+      # Typography
+      {
+        &typography/1,
+        [
+          align: ["center", "justify", "left", "right"],
+          color: Theme.colors(),
+          variant: ["h1", "h2", "h3", "h4", "p"]
+        ]
+      }
+    ]
+    |> Enum.map(fn {fun, args} -> generate_component_classes(fun, args) end)
     |> List.flatten()
     |> Enum.uniq()
     |> Enum.sort()
@@ -40,12 +286,48 @@ defmodule Mix.Tasks.Tailwind.GenerateClasses do
     Mix.Task.run("format")
   end
 
-  defp convert_path_to_module(path) do
-    file = Path.basename(path, ".ex")
-    Module.concat(["PhoenixUI", "Components", Macro.camelize(file)])
+  defp generate_component_classes(component, attr_permutations) do
+    attr_permutations
+    |> Keyword.put_new(:inner_block, [[]])
+    |> Enum.map(fn {prop, opts} ->
+      Enum.map(opts, fn opt -> Map.put(%{}, prop, opt) end)
+    end)
+    |> Enum.reduce(nil, &permutation/2)
+    |> Enum.map(&extract_classes(&1, component))
+    |> List.flatten()
+    |> Enum.uniq()
+    |> Enum.sort()
   end
 
-  defp generatable?(module) do
-    Code.ensure_loaded?(module) && function_exported?(module, :classes, 0)
+  defp permutation(set1, nil), do: set1
+
+  defp permutation(set1, set2) do
+    Enum.reduce(set1, [], fn item1, acc ->
+      Enum.reduce(set2, acc, fn item2, acc ->
+        [Map.merge(item1, item2) | acc]
+      end)
+    end)
+  end
+
+  defp extract_classes(assigns, component) do
+    html = render_component(component, assigns)
+
+    ~r/(?<=class=\").*?(?=\")/
+    |> Regex.scan(html)
+    |> List.flatten()
+    |> Enum.map(&String.split/1)
+  end
+
+  defp range(first, last, step), do: apply_range([truncate(first)], last, step)
+
+  defp apply_range([current | _] = acc, last, step) when current < last do
+    apply_range([truncate(current + step) | acc], last, step)
+  end
+
+  defp apply_range(acc, _last, _step), do: Enum.reverse(acc)
+
+  defp truncate(val) do
+    truncated = trunc(val)
+    if val - truncated != 0, do: val, else: truncated
   end
 end

--- a/lib/phoenix_ui.ex
+++ b/lib/phoenix_ui.ex
@@ -1,15 +1,15 @@
-defmodule PhoenixUI do
+defmodule Phoenix.UI do
   @moduledoc """
-  Documentation for `PhoenixUI`.
+  Documentation for `Phoenix.UI`.
   """
 
   defmacro __using__(which) when is_atom(which), do: apply(__MODULE__, which, [])
 
   defmacro __using__(_opts) do
     quote generated: true, location: :keep do
-      alias PhoenixUI.Components.{Autocomplete, Dropdown, SelectFilter, TextFilter}
+      alias Phoenix.UI.Components.{Autocomplete, Dropdown, SelectFilter, TextFilter}
 
-      import PhoenixUI.Components.{
+      import Phoenix.UI.Components.{
         Accordion,
         Alert,
         Avatar,
@@ -51,31 +51,31 @@ defmodule PhoenixUI do
   end
 
   @doc """
-  Helper macro for creating a PhoenixUI component.
+  Helper macro for creating a Phoenix.UI component.
 
   ## Examples
 
-      use PhoenixUI, :component
+      use Phoenix.UI, :component
 
   """
   @spec component() :: Macro.t()
   def component do
     quote generated: true, location: :keep do
       alias Phoenix.LiveView.{JS, Rendered, Socket}
-      alias PhoenixUI.Theme
+      alias Phoenix.UI.Theme
 
-      import PhoenixUI.Helpers
+      import Phoenix.UI.Helpers
 
       use Phoenix.Component
     end
   end
 
   @doc """
-  Helper macro for creating a PhoenixUI live_component.
+  Helper macro for creating a Phoenix.UI live_component.
 
   ## Examples
 
-      use PhoenixUI, :live_component
+      use Phoenix.UI, :live_component
 
   """
   @spec live_component() :: Macro.t()
@@ -83,7 +83,7 @@ defmodule PhoenixUI do
     quote generated: true, location: :keep do
       alias Phoenix.LiveView.Socket
 
-      import PhoenixUI.Helpers
+      import Phoenix.UI.Helpers
 
       use Phoenix.LiveComponent
     end

--- a/lib/phoenix_ui.ex
+++ b/lib/phoenix_ui.ex
@@ -9,9 +9,6 @@ defmodule PhoenixUI do
     quote generated: true, location: :keep do
       alias PhoenixUI.Components.{Autocomplete, Dropdown, SelectFilter, TextFilter}
 
-      import PhoenixUI.Components.Divider, only: [divider: 1]
-      import PhoenixUI.Components.Link, only: [a: 1]
-
       import PhoenixUI.Components.{
         Accordion,
         Alert,
@@ -28,6 +25,7 @@ defmodule PhoenixUI do
         Collapse,
         Container,
         DescriptionList,
+        Divider,
         Drawer,
         Dropdown,
         ErrorTag,
@@ -38,6 +36,7 @@ defmodule PhoenixUI do
         HiddenInput,
         Label,
         List,
+        Link,
         Menu,
         Modal,
         Paper,

--- a/lib/phoenix_ui/components/accordion.ex
+++ b/lib/phoenix_ui/components/accordion.ex
@@ -1,10 +1,10 @@
-defmodule PhoenixUI.Components.Accordion do
+defmodule Phoenix.UI.Components.Accordion do
   @moduledoc """
   Provides accordion component.
   """
-  import PhoenixUI.{Components.Collapse, Components.Heroicon}
+  import Phoenix.UI.{Components.Collapse, Components.Heroicon}
 
-  use PhoenixUI, :component
+  use Phoenix.UI, :component
 
   @default_icon_color "slate"
   @default_icon_name_closed "chevron-up"

--- a/lib/phoenix_ui/components/accordion.ex
+++ b/lib/phoenix_ui/components/accordion.ex
@@ -63,25 +63,6 @@ defmodule PhoenixUI.Components.Accordion do
     """
   end
 
-  @doc """
-  Returns all possible component classes for Tailwind CSS JIT compilation.
-
-  ## Examples
-
-      iex> classes()
-      ["class1", "class2", ...]
-
-  """
-  @spec classes :: [String.t()]
-  def classes do
-    generate_all_classes(&accordion/1,
-      header: [[%{inner_block: fn _, _ -> "header" end}]],
-      id: ["accordion"],
-      open: [true, false],
-      panel: [[%{inner_block: fn _, _ -> "panel" end}]]
-    )
-  end
-
   ### JS Interactions ##########################
 
   @doc """

--- a/lib/phoenix_ui/components/alert.ex
+++ b/lib/phoenix_ui/components/alert.ex
@@ -1,10 +1,10 @@
-defmodule PhoenixUI.Components.Alert do
+defmodule Phoenix.UI.Components.Alert do
   @moduledoc """
   Provides Alert component
   """
-  import PhoenixUI.Components.Heroicon
+  import Phoenix.UI.Components.Heroicon
 
-  use PhoenixUI, :component
+  use Phoenix.UI, :component
 
   @default_action_icon_name "x-mark"
   @default_icon_color "inherity"

--- a/lib/phoenix_ui/components/alert.ex
+++ b/lib/phoenix_ui/components/alert.ex
@@ -77,24 +77,6 @@ defmodule PhoenixUI.Components.Alert do
     """
   end
 
-  @doc """
-  Returns all possible component classes for Tailwind CSS JIT compilation.
-
-  ## Examples
-
-      iex> classes()
-      ["class1", "class2", ...]
-
-  """
-  @spec classes :: [String.t()]
-  def classes do
-    generate_all_classes(&alert/1,
-      action: [["phx-click": "lv:clear-flash"]],
-      severity: ["error", "info", "success", "warning"],
-      variant: ["filled", "outlined", "standard"]
-    )
-  end
-
   ### Container Attrs ##########################
 
   defp build_container_attrs(assigns) do

--- a/lib/phoenix_ui/components/autocomplete.ex
+++ b/lib/phoenix_ui/components/autocomplete.ex
@@ -1,12 +1,12 @@
-defmodule PhoenixUI.Components.Autocomplete do
+defmodule Phoenix.UI.Components.Autocomplete do
   @moduledoc """
   Provides text filter component.
   """
-  alias PhoenixUI.Components.TextFilter
+  alias Phoenix.UI.Components.TextFilter
 
-  import PhoenixUI.Components.Menu
+  import Phoenix.UI.Components.Menu
 
-  use PhoenixUI, :live_component
+  use Phoenix.UI, :live_component
 
   @impl true
   def render(assigns) do

--- a/lib/phoenix_ui/components/avatar.ex
+++ b/lib/phoenix_ui/components/avatar.ex
@@ -37,26 +37,6 @@ defmodule PhoenixUI.Components.Avatar do
     |> generate_markup()
   end
 
-  @doc """
-  Returns all possible component classes for Tailwind CSS JIT compilation.
-
-  ## Examples
-
-      iex> classes()
-      ["class1", "class2", ...]
-
-  """
-  @spec classes :: [String.t()]
-  def classes do
-    generate_all_classes(&avatar/1,
-      inner_block: [nil, []],
-      color: Theme.colors(),
-      border: [true, false],
-      size: ["xs", "sm", "md", "lg", "xl"] ++ range(0.25, 20, 0.25),
-      variant: ["circular", "rounded", "square"]
-    )
-  end
-
   ### Markup ##########################
 
   defp generate_markup(%{src: src} = assigns) when not is_nil(src) do

--- a/lib/phoenix_ui/components/avatar.ex
+++ b/lib/phoenix_ui/components/avatar.ex
@@ -1,10 +1,10 @@
-defmodule PhoenixUI.Components.Avatar do
+defmodule Phoenix.UI.Components.Avatar do
   @moduledoc """
   Provides avatar component.
   """
-  import PhoenixUI.Components.Heroicon, only: [heroicon: 1]
+  import Phoenix.UI.Components.Heroicon
 
-  use PhoenixUI, :component
+  use Phoenix.UI, :component
 
   attr(:border, :boolean, default: false)
   attr(:color, :string, default: "slate")

--- a/lib/phoenix_ui/components/avatar_group.ex
+++ b/lib/phoenix_ui/components/avatar_group.ex
@@ -1,10 +1,10 @@
-defmodule PhoenixUI.Components.AvatarGroup do
+defmodule Phoenix.UI.Components.AvatarGroup do
   @moduledoc """
   Provides avatar_group component.
   """
-  import PhoenixUI.Components.Avatar, only: [avatar: 1]
+  import Phoenix.UI.Components.Avatar, only: [avatar: 1]
 
-  use PhoenixUI, :component
+  use Phoenix.UI, :component
 
   attr(:border, :boolean, default: true)
   attr(:color, :string, default: "slate")

--- a/lib/phoenix_ui/components/avatar_group.ex
+++ b/lib/phoenix_ui/components/avatar_group.ex
@@ -63,27 +63,6 @@ defmodule PhoenixUI.Components.AvatarGroup do
     """
   end
 
-  @doc """
-  Returns all possible component classes for Tailwind CSS JIT compilation.
-
-  ## Examples
-
-      iex> classes()
-      ["class1", "class2", ...]
-
-  """
-  @spec classes :: [String.t()]
-  def classes do
-    generate_all_classes(&avatar_group/1,
-      avatar: [[%{inner_block: nil}]],
-      color: Theme.colors(),
-      inner_block: [nil, []],
-      size: ["xs", "sm", "md", "lg", "xl"],
-      spacing: ["xs", "sm", "md", "lg", "xl"],
-      variant: ["circular", "rounded", "square"]
-    )
-  end
-
   defp calc_total(%{avatar: avatars} = assigns) do
     assign_new(assigns, :total, fn -> length(avatars) end)
   end

--- a/lib/phoenix_ui/components/backdrop.ex
+++ b/lib/phoenix_ui/components/backdrop.ex
@@ -1,8 +1,8 @@
-defmodule PhoenixUI.Components.Backdrop do
+defmodule Phoenix.UI.Components.Backdrop do
   @moduledoc """
   Provides Backdrop component.
   """
-  use PhoenixUI, :component
+  use Phoenix.UI, :component
 
   attr(:element, :string, default: "div")
   attr(:invisible, :boolean, default: false)

--- a/lib/phoenix_ui/components/backdrop.ex
+++ b/lib/phoenix_ui/components/backdrop.ex
@@ -42,24 +42,6 @@ defmodule PhoenixUI.Components.Backdrop do
     """
   end
 
-  @doc """
-  Returns all possible component classes for Tailwind CSS JIT compilation.
-
-  ## Examples
-
-      iex> classes()
-      ["class1", "class2", ...]
-
-  """
-  @spec classes :: [String.t()]
-  def classes do
-    generate_all_classes(&backdrop/1,
-      invisible: [true, false],
-      open: [true, false],
-      transition_duration: Theme.transition_durations()
-    )
-  end
-
   ### JS Interactions ##########################
 
   @doc """

--- a/lib/phoenix_ui/components/badge.ex
+++ b/lib/phoenix_ui/components/badge.ex
@@ -1,8 +1,8 @@
-defmodule PhoenixUI.Components.Badge do
+defmodule Phoenix.UI.Components.Badge do
   @moduledoc """
   Provides badge component.
   """
-  use PhoenixUI, :component
+  use Phoenix.UI, :component
 
   @default_border false
   @default_color "blue"

--- a/lib/phoenix_ui/components/badge.ex
+++ b/lib/phoenix_ui/components/badge.ex
@@ -52,38 +52,6 @@ defmodule PhoenixUI.Components.Badge do
     """
   end
 
-  @doc """
-  Returns all possible component classes for Tailwind CSS JIT compilation.
-
-  ## Examples
-
-      iex> classes()
-      ["class1", "class2", ...]
-
-  """
-  @spec classes :: [String.t()]
-  def classes do
-    generate_all_classes(&badge/1,
-      color: Theme.colors(),
-      content: [""],
-      position: [
-        "bottom_end",
-        "bottom_start",
-        "bottom",
-        "left_end",
-        "left_start",
-        "left",
-        "right_end",
-        "right_start",
-        "right",
-        "top_end",
-        "top_start",
-        "top"
-      ],
-      variant: ["dot", "standard"]
-    )
-  end
-
   ### Wrapper Attrs ##########################
 
   defp build_wrapper_attrs(assigns) do

--- a/lib/phoenix_ui/components/breadcrumbs.ex
+++ b/lib/phoenix_ui/components/breadcrumbs.ex
@@ -1,10 +1,10 @@
-defmodule PhoenixUI.Components.Breadcrumbs do
+defmodule Phoenix.UI.Components.Breadcrumbs do
   @moduledoc """
   Provides breadcrumbs component.
   """
-  import PhoenixUI.Components.{Heroicon, Link}
+  import Phoenix.UI.Components.{Heroicon, Link}
 
-  use PhoenixUI, :component
+  use Phoenix.UI, :component
 
   @default_link_color "slate"
   @default_separator "chevron-right"

--- a/lib/phoenix_ui/components/breadcrumbs.ex
+++ b/lib/phoenix_ui/components/breadcrumbs.ex
@@ -50,27 +50,6 @@ defmodule PhoenixUI.Components.Breadcrumbs do
     """
   end
 
-  @doc """
-  Returns all possible component classes for Tailwind CSS JIT compilation.
-
-  ## Examples
-
-      iex> classes()
-      ["class1", "class2", ...]
-
-  """
-  @spec classes :: [String.t()]
-  def classes do
-    generate_all_classes(&breadcrumbs/1,
-      a: [
-        [
-          %{inner_block: fn _, _ -> "Phoenix UI" end},
-          %{inner_block: fn _, _ -> "Components" end}
-        ]
-      ]
-    )
-  end
-
   ### Nav Attrs ##########################
 
   defp build_nav_attrs(assigns) do

--- a/lib/phoenix_ui/components/button.ex
+++ b/lib/phoenix_ui/components/button.ex
@@ -1,8 +1,8 @@
-defmodule PhoenixUI.Components.Button do
+defmodule Phoenix.UI.Components.Button do
   @moduledoc """
   Provides button component.
   """
-  use PhoenixUI, :component
+  use Phoenix.UI, :component
 
   attr(:color, :string, default: "blue")
   attr(:disabled, :boolean, default: false)

--- a/lib/phoenix_ui/components/button.ex
+++ b/lib/phoenix_ui/components/button.ex
@@ -35,26 +35,6 @@ defmodule PhoenixUI.Components.Button do
     """
   end
 
-  @doc """
-  Returns all possible component classes for Tailwind CSS JIT compilation.
-
-  ## Examples
-
-      iex> classes()
-      ["class1", "class2", ...]
-
-  """
-  @spec classes :: [String.t()]
-  def classes do
-    generate_all_classes(&button/1,
-      color: Theme.colors(),
-      disabled: [true, false],
-      size: ["xs", "sm", "md", "lg", "xl"],
-      square: [true, false],
-      variant: ["contained", "icon", "outlined", "text"]
-    )
-  end
-
   ### Btn Attrs ##########################
 
   defp build_btn_attrs(assigns) do

--- a/lib/phoenix_ui/components/button_group.ex
+++ b/lib/phoenix_ui/components/button_group.ex
@@ -1,10 +1,10 @@
-defmodule PhoenixUI.Components.ButtonGroup do
+defmodule Phoenix.UI.Components.ButtonGroup do
   @moduledoc """
   Provides a button_group component.
   """
-  import PhoenixUI.Components.Button, only: [button: 1]
+  import Phoenix.UI.Components.Button, only: [button: 1]
 
-  use PhoenixUI, :component
+  use Phoenix.UI, :component
 
   attr(:color, :string, default: "blue")
   attr(:disabled, :boolean, default: true)

--- a/lib/phoenix_ui/components/card.ex
+++ b/lib/phoenix_ui/components/card.ex
@@ -1,10 +1,10 @@
-defmodule PhoenixUI.Components.Card do
+defmodule Phoenix.UI.Components.Card do
   @moduledoc """
   Provides card component.
   """
-  import PhoenixUI.Components.{Avatar, AvatarGroup, Paper, Typography}
+  import Phoenix.UI.Components.{Avatar, AvatarGroup, Paper, Typography}
 
-  use PhoenixUI, :component
+  use Phoenix.UI, :component
 
   attr(:element, :string)
 

--- a/lib/phoenix_ui/components/card.ex
+++ b/lib/phoenix_ui/components/card.ex
@@ -218,37 +218,6 @@ defmodule PhoenixUI.Components.Card do
     """
   end
 
-  @doc """
-  Returns all possible component classes for Tailwind CSS JIT compilation.
-
-  ## Examples
-
-      iex> classes()
-      ["class1", "class2", ...]
-
-  """
-  @spec classes :: [String.t()]
-  def classes do
-    [
-      # Card
-      generate_all_classes(&card/1,
-        elevation: [0, 1, 2, 3, 4, 5],
-        square: [true, false],
-        variant: ["elevated", "outlined"]
-      ),
-      # Card Header
-      generate_all_classes(&card_header/1, []),
-      # Card Media
-      generate_all_classes(&card_media/1, src: [""]),
-      # Card Content
-      generate_all_classes(&card_content/1, []),
-      # Card Actions
-      generate_all_classes(&card_action/1, [])
-    ]
-    |> List.flatten()
-    |> Enum.uniq()
-  end
-
   ### Card Header Attrs ##########################
 
   defp build_card_header_attrs(assigns) do

--- a/lib/phoenix_ui/components/checkbox.ex
+++ b/lib/phoenix_ui/components/checkbox.ex
@@ -1,11 +1,11 @@
-defmodule PhoenixUI.Components.Checkbox do
+defmodule Phoenix.UI.Components.Checkbox do
   @moduledoc """
   Provides checkbox component.
   """
   import Phoenix.HTML.Form, only: [checkbox: 3, humanize: 1]
-  import PhoenixUI.Components.{ErrorTag, FormGroup, HelperText, Label}
+  import Phoenix.UI.Components.{ErrorTag, FormGroup, HelperText, Label}
 
-  use PhoenixUI, :component
+  use Phoenix.UI, :component
 
   @default_margin true
   @default_phx_debounce "blur"

--- a/lib/phoenix_ui/components/chip.ex
+++ b/lib/phoenix_ui/components/chip.ex
@@ -1,10 +1,10 @@
-defmodule PhoenixUI.Components.Chip do
+defmodule Phoenix.UI.Components.Chip do
   @moduledoc """
   Provides chip component.
   """
-  import PhoenixUI.Components.{Avatar, Heroicon}
+  import Phoenix.UI.Components.{Avatar, Heroicon}
 
-  use PhoenixUI, :component
+  use Phoenix.UI, :component
 
   @default_avatar_size 2
   @default_delete_icon_name "x-circle"

--- a/lib/phoenix_ui/components/chip.ex
+++ b/lib/phoenix_ui/components/chip.ex
@@ -52,26 +52,6 @@ defmodule PhoenixUI.Components.Chip do
     """
   end
 
-  @doc """
-  Returns all possible component classes for Tailwind CSS JIT compilation.
-
-  ## Examples
-
-      iex> classes()
-      ["class1", "class2", ...]
-
-  """
-  @spec classes :: [String.t()]
-  def classes do
-    generate_all_classes(&chip/1,
-      color: Theme.colors(),
-      label: ["label"],
-      on_click: ["handle_click"],
-      on_delete: ["handle_delete"],
-      variant: ["filled", "outlined"]
-    )
-  end
-
   ### Chip Attrs ##########################
 
   defp build_chip_attrs(assigns) do

--- a/lib/phoenix_ui/components/collapse.ex
+++ b/lib/phoenix_ui/components/collapse.ex
@@ -33,25 +33,6 @@ defmodule PhoenixUI.Components.Collapse do
     """
   end
 
-  @doc """
-  Returns all possible component classes for Tailwind CSS JIT compilation.
-
-  ## Examples
-
-      iex> classes()
-      ["class1", "class2", ...]
-
-  """
-  @spec classes :: [String.t()]
-  def classes do
-    generate_all_classes(&collapse/1,
-      max_size: Enum.map(range(100, 5000, 100), &"#{&1}px"),
-      open: [true, false],
-      orientation: ["horizontal", "vertical"],
-      transition_duration: Theme.transition_durations()
-    )
-  end
-
   ### JS Interactions ##########################
 
   @doc """

--- a/lib/phoenix_ui/components/collapse.ex
+++ b/lib/phoenix_ui/components/collapse.ex
@@ -1,8 +1,8 @@
-defmodule PhoenixUI.Components.Collapse do
+defmodule Phoenix.UI.Components.Collapse do
   @moduledoc """
   Provides collapse component.
   """
-  use PhoenixUI, :component
+  use Phoenix.UI, :component
 
   attr(:element, :string, default: "div")
   attr(:max_size, :string, default: "5000px")

--- a/lib/phoenix_ui/components/container.ex
+++ b/lib/phoenix_ui/components/container.ex
@@ -31,23 +31,6 @@ defmodule PhoenixUI.Components.Container do
     """
   end
 
-  @doc """
-  Returns all possible component classes for Tailwind CSS JIT compilation.
-
-  ## Examples
-
-      iex> classes()
-      ["class1", "class2", ...]
-
-  """
-  @spec classes :: [String.t()]
-  def classes do
-    generate_all_classes(&container/1,
-      max_width: Theme.max_widths(),
-      variant: ["fixed", "fluid"]
-    )
-  end
-
   ### Container Attrs ##########################
 
   defp build_container_attrs(assigns) do

--- a/lib/phoenix_ui/components/container.ex
+++ b/lib/phoenix_ui/components/container.ex
@@ -1,8 +1,8 @@
-defmodule PhoenixUI.Components.Container do
+defmodule Phoenix.UI.Components.Container do
   @moduledoc """
   Provides container component.
   """
-  use PhoenixUI, :component
+  use Phoenix.UI, :component
 
   attr(:element, :string, default: "div")
   attr(:max_width, :string, default: "screen-lg")

--- a/lib/phoenix_ui/components/description_list.ex
+++ b/lib/phoenix_ui/components/description_list.ex
@@ -1,8 +1,8 @@
-defmodule PhoenixUI.Components.DescriptionList do
+defmodule Phoenix.UI.Components.DescriptionList do
   @moduledoc """
   Provides description list component.
   """
-  use PhoenixUI, :component
+  use Phoenix.UI, :component
 
   @default_variant :simple
   @default_striped false

--- a/lib/phoenix_ui/components/divider.ex
+++ b/lib/phoenix_ui/components/divider.ex
@@ -30,23 +30,6 @@ defmodule PhoenixUI.Components.Divider do
     """
   end
 
-  @doc """
-  Returns all possible component classes for Tailwind CSS JIT compilation.
-
-  ## Examples
-
-      iex> classes()
-      ["class1", "class2", ...]
-
-  """
-  @spec classes :: [String.t()]
-  def classes do
-    generate_all_classes(&divider/1,
-      color: Theme.colors(),
-      variant: ["full_width", "inset", "middle"]
-    )
-  end
-
   ### Divider Attrs ##########################
 
   defp build_divider_attrs(assigns) do

--- a/lib/phoenix_ui/components/divider.ex
+++ b/lib/phoenix_ui/components/divider.ex
@@ -1,8 +1,8 @@
-defmodule PhoenixUI.Components.Divider do
+defmodule Phoenix.UI.Components.Divider do
   @moduledoc """
   Provides divider component.
   """
-  use PhoenixUI, :component
+  use Phoenix.UI, :component
 
   @default_color "slate"
   @default_variant "full_width"

--- a/lib/phoenix_ui/components/drawer.ex
+++ b/lib/phoenix_ui/components/drawer.ex
@@ -50,24 +50,6 @@ defmodule PhoenixUI.Components.Drawer do
     """
   end
 
-  @doc """
-  Returns all possible component classes for Tailwind CSS JIT compilation.
-
-  ## Examples
-
-      iex> classes()
-      ["class1", "class2", ...]
-
-  """
-  @spec classes :: [String.t()]
-  def classes do
-    PhoenixUI.Helpers.generate_all_classes(&drawer/1,
-      id: ["drawer"],
-      open: [true, false],
-      variant: [:temporary]
-    )
-  end
-
   ### JS Interactions ##########################
 
   @doc """

--- a/lib/phoenix_ui/components/drawer.ex
+++ b/lib/phoenix_ui/components/drawer.ex
@@ -1,10 +1,10 @@
-defmodule PhoenixUI.Components.Drawer do
+defmodule Phoenix.UI.Components.Drawer do
   @moduledoc """
   Provides drawer component.
   """
-  import PhoenixUI.Components.{Backdrop, Paper}
+  import Phoenix.UI.Components.{Backdrop, Paper}
 
-  use PhoenixUI, :component
+  use Phoenix.UI, :component
 
   @default_anchor "left"
   @default_open false

--- a/lib/phoenix_ui/components/dropdown.ex
+++ b/lib/phoenix_ui/components/dropdown.ex
@@ -1,10 +1,10 @@
-defmodule PhoenixUI.Components.Dropdown do
+defmodule Phoenix.UI.Components.Dropdown do
   @moduledoc """
   Provides dropdown component.
   """
-  import PhoenixUI.Components.Menu
+  import Phoenix.UI.Components.Menu
 
-  use PhoenixUI, :component
+  use Phoenix.UI, :component
 
   @default_variant "elevated"
 

--- a/lib/phoenix_ui/components/error_tag.ex
+++ b/lib/phoenix_ui/components/error_tag.ex
@@ -1,10 +1,10 @@
-defmodule PhoenixUI.Components.ErrorTag do
+defmodule Phoenix.UI.Components.ErrorTag do
   @moduledoc """
   Provides error tag component.
   """
   import Phoenix.HTML.Form
 
-  use PhoenixUI, :component
+  use Phoenix.UI, :component
 
   attr(:color, :string, default: "red")
   attr(:variant, :string, default: "p")

--- a/lib/phoenix_ui/components/form_group.ex
+++ b/lib/phoenix_ui/components/form_group.ex
@@ -1,8 +1,8 @@
-defmodule PhoenixUI.Components.FormGroup do
+defmodule Phoenix.UI.Components.FormGroup do
   @moduledoc """
   Provides form group component.
   """
-  use PhoenixUI, :component
+  use Phoenix.UI, :component
 
   attr(:element, :string, default: "div")
   attr(:margin, :boolean, default: true)

--- a/lib/phoenix_ui/components/grid.ex
+++ b/lib/phoenix_ui/components/grid.ex
@@ -1,8 +1,8 @@
-defmodule PhoenixUI.Components.Grid do
+defmodule Phoenix.UI.Components.Grid do
   @moduledoc """
   Provides grid component.
   """
-  use PhoenixUI, :component
+  use Phoenix.UI, :component
 
   attr(:columns, :integer, default: 12)
   attr(:element, :string, default: "div")

--- a/lib/phoenix_ui/components/grid.ex
+++ b/lib/phoenix_ui/components/grid.ex
@@ -30,25 +30,6 @@ defmodule PhoenixUI.Components.Grid do
     """
   end
 
-  @doc """
-  Returns all possible component classes for Tailwind CSS JIT compilation.
-
-  ## Examples
-
-      iex> classes()
-      ["class1", "class2", ...]
-
-  """
-  @spec classes :: [String.t()]
-  def classes do
-    generate_all_classes(&grid/1,
-      column_spacing: 1..12,
-      columns: 1..12,
-      row_spacing: 1..12,
-      spacing: 1..12
-    )
-  end
-
   ### Grid Attrs ##########################
 
   defp build_grid_attrs(assigns) do

--- a/lib/phoenix_ui/components/helper_text.ex
+++ b/lib/phoenix_ui/components/helper_text.ex
@@ -1,8 +1,8 @@
-defmodule PhoenixUI.Components.HelperText do
+defmodule Phoenix.UI.Components.HelperText do
   @moduledoc """
   Provides helper text component.
   """
-  use PhoenixUI, :component
+  use Phoenix.UI, :component
 
   attr(:disabled, :boolean, default: false)
   attr(:element, :string, default: "div")

--- a/lib/phoenix_ui/components/heroicon.ex
+++ b/lib/phoenix_ui/components/heroicon.ex
@@ -32,25 +32,6 @@ defmodule PhoenixUI.Components.Heroicon do
     |> render_markup()
   end
 
-  @doc """
-  Returns all component classes for Tailwind CSS JIT compilation.
-
-  ## Examples
-
-      iex> classes()
-      ["class1", "class2", ...]
-
-  """
-  @spec classes :: [String.t()]
-  def classes do
-    generate_all_classes(&heroicon/1,
-      color: Theme.colors(),
-      name: ["academic-cap"],
-      size: ["xs", "sm", "md", "lg", "xl"] ++ range(0.25, 20, 0.25),
-      variant: ["outline", "solid"]
-    )
-  end
-
   ### CSS Classes ##########################
 
   # Color

--- a/lib/phoenix_ui/components/heroicon.ex
+++ b/lib/phoenix_ui/components/heroicon.ex
@@ -1,8 +1,8 @@
-defmodule PhoenixUI.Components.Heroicon do
+defmodule Phoenix.UI.Components.Heroicon do
   @moduledoc """
   Provides heroicon component.
   """
-  use PhoenixUI, :component
+  use Phoenix.UI, :component
 
   attr(:color, :string, default: "inherit")
   attr(:name, :string, required: true)

--- a/lib/phoenix_ui/components/hidden_input.ex
+++ b/lib/phoenix_ui/components/hidden_input.ex
@@ -1,10 +1,10 @@
-defmodule PhoenixUI.Components.HiddenInput do
+defmodule Phoenix.UI.Components.HiddenInput do
   @moduledoc """
   Provides hidden input component.
   """
   import Phoenix.HTML.Form, only: [hidden_input: 3]
 
-  use PhoenixUI, :component
+  use Phoenix.UI, :component
 
   @doc """
   Renders hidden input component.

--- a/lib/phoenix_ui/components/label.ex
+++ b/lib/phoenix_ui/components/label.ex
@@ -1,10 +1,10 @@
-defmodule PhoenixUI.Components.Label do
+defmodule Phoenix.UI.Components.Label do
   @moduledoc """
   Provides label component.
   """
   import Phoenix.HTML.Form
 
-  use PhoenixUI, :component
+  use Phoenix.UI, :component
 
   @default_disabled false
   @default_margin true

--- a/lib/phoenix_ui/components/link.ex
+++ b/lib/phoenix_ui/components/link.ex
@@ -1,8 +1,8 @@
-defmodule PhoenixUI.Components.Link do
+defmodule Phoenix.UI.Components.Link do
   @moduledoc """
   Provides a component.
   """
-  use PhoenixUI, :component
+  use Phoenix.UI, :component
 
   @default_color "blue"
   @default_disabled false

--- a/lib/phoenix_ui/components/link.ex
+++ b/lib/phoenix_ui/components/link.ex
@@ -34,23 +34,6 @@ defmodule PhoenixUI.Components.Link do
     """
   end
 
-  @doc """
-  Returns all possible component classes for Tailwind CSS JIT compilation.
-
-  ## Examples
-
-      iex> classes()
-      ["class1", "class2", ...]
-
-  """
-  @spec classes :: [String.t()]
-  def classes do
-    generate_all_classes(&a/1,
-      color: Theme.colors(),
-      disabled: [false, true]
-    )
-  end
-
   ### Link Attrs ##########################
 
   defp build_link_attrs(assigns) do

--- a/lib/phoenix_ui/components/list.ex
+++ b/lib/phoenix_ui/components/list.ex
@@ -1,8 +1,8 @@
-defmodule PhoenixUI.Components.List do
+defmodule Phoenix.UI.Components.List do
   @moduledoc """
   Provides list component.
   """
-  use PhoenixUI, :component
+  use Phoenix.UI, :component
 
   attr(:element, :string, default: "ul")
 

--- a/lib/phoenix_ui/components/list.ex
+++ b/lib/phoenix_ui/components/list.ex
@@ -50,37 +50,44 @@ defmodule PhoenixUI.Components.List do
   """
   @spec list_item(Socket.assigns()) :: Rendered.t()
   def list_item(prev_assigns) do
-    assigns =
-      prev_assigns
-      |> assign_class(~w(
+    prev_assigns
+    |> assign_class(~w(
         block w-full whitespace-nowrap py-2 px-4 text-sm font-normal
         text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-100/25
       ))
-      |> assign_rest([:element])
+    |> assign_rest([:element])
+    |> list_item_markup()
+  end
 
+  defp list_item_markup(%{href: _} = assigns) do
+    ~H"""
+    <.link name={@element} {@rest}>
+      <%= render_slot(@inner_block) %>
+    </.link>
+    """
+  end
+
+  defp list_item_markup(%{navigate: _} = assigns) do
+    ~H"""
+    <.link name={@element} {@rest}>
+      <%= render_slot(@inner_block) %>
+    </.link>
+    """
+  end
+
+  defp list_item_markup(%{patch: _} = assigns) do
+    ~H"""
+    <.link {@rest}>
+      <%= render_slot(@inner_block) %>
+    </.link>
+    """
+  end
+
+  defp list_item_markup(assigns) do
     ~H"""
     <.dynamic_tag name={@element} {@rest}>
       <%= render_slot(@inner_block) %>
     </.dynamic_tag>
     """
-  end
-
-  @doc """
-  Returns all possible component classes for Tailwind CSS JIT compilation.
-
-  ## Examples
-
-      iex> classes()
-      ["class1", "class2", ...]
-
-  """
-  @spec classes :: [String.t()]
-  def classes do
-    [
-      generate_all_classes(&list/1, []),
-      generate_all_classes(&list_item/1, [])
-    ]
-    |> List.flatten()
-    |> Enum.uniq()
   end
 end

--- a/lib/phoenix_ui/components/menu.ex
+++ b/lib/phoenix_ui/components/menu.ex
@@ -1,10 +1,10 @@
-defmodule PhoenixUI.Components.Menu do
+defmodule Phoenix.UI.Components.Menu do
   @moduledoc """
   Provides menu component.
   """
-  import PhoenixUI.Components.Paper
+  import Phoenix.UI.Components.Paper
 
-  use PhoenixUI, :component
+  use Phoenix.UI, :component
 
   attr(:element, :string, default: "ul")
 

--- a/lib/phoenix_ui/components/modal.ex
+++ b/lib/phoenix_ui/components/modal.ex
@@ -58,24 +58,6 @@ defmodule PhoenixUI.Components.Modal do
     """
   end
 
-  @doc """
-  Returns all possible component classes for Tailwind CSS JIT compilation.
-
-  ## Examples
-
-      iex> classes()
-      ["class1", "class2", ...]
-
-  """
-  @spec classes :: [String.t()]
-  def classes do
-    PhoenixUI.Helpers.generate_all_classes(&modal/1,
-      id: ["modal"],
-      max_width: [:xs, :sm, :md, :lg, :xl],
-      open: [true, false]
-    )
-  end
-
   ### JS Interactions ##########################
 
   @doc """

--- a/lib/phoenix_ui/components/modal.ex
+++ b/lib/phoenix_ui/components/modal.ex
@@ -1,10 +1,10 @@
-defmodule PhoenixUI.Components.Modal do
+defmodule Phoenix.UI.Components.Modal do
   @moduledoc """
   Provides modal component.
   """
-  import PhoenixUI.Components.{Backdrop, Paper}
+  import Phoenix.UI.Components.{Backdrop, Paper}
 
-  use PhoenixUI, :component
+  use Phoenix.UI, :component
 
   @default_max_width :sm
   @default_open false

--- a/lib/phoenix_ui/components/paper.ex
+++ b/lib/phoenix_ui/components/paper.ex
@@ -41,25 +41,6 @@ defmodule PhoenixUI.Components.Paper do
     """
   end
 
-  @doc """
-  Returns all possible component classes for Tailwind CSS JIT compilation.
-
-  ## Examples
-
-      iex> classes()
-      ["class1", "class2", ...]
-
-  """
-  @spec classes :: [String.t()]
-  def classes do
-    generate_all_classes(&paper/1,
-      blur: [true, false, "none", "sm", "md", "lg", "xl", "2xl", "3xl"],
-      elevation: [0, 1, 2, 3, 4, 5],
-      square: [true, false],
-      variant: ["elevated", "outlined"]
-    )
-  end
-
   ### CSS Classes ##########################
 
   # Blur

--- a/lib/phoenix_ui/components/paper.ex
+++ b/lib/phoenix_ui/components/paper.ex
@@ -1,8 +1,8 @@
-defmodule PhoenixUI.Components.Paper do
+defmodule Phoenix.UI.Components.Paper do
   @moduledoc """
   Provides paper component.
   """
-  use PhoenixUI, :component
+  use Phoenix.UI, :component
 
   attr(:blur, :boolean, default: false)
   attr(:element, :string, default: "div")

--- a/lib/phoenix_ui/components/select.ex
+++ b/lib/phoenix_ui/components/select.ex
@@ -1,11 +1,11 @@
-defmodule PhoenixUI.Components.Select do
+defmodule Phoenix.UI.Components.Select do
   @moduledoc """
   Provides select component.
   """
   import Phoenix.HTML.Form, only: [select: 4]
-  import PhoenixUI.Components.{ErrorTag, FormGroup, HelperText, Heroicon, Label}
+  import Phoenix.UI.Components.{ErrorTag, FormGroup, HelperText, Heroicon, Label}
 
-  use PhoenixUI, :component
+  use Phoenix.UI, :component
 
   @default_end_adornment "chevron-down"
   @default_full_width false

--- a/lib/phoenix_ui/components/select_filter.ex
+++ b/lib/phoenix_ui/components/select_filter.ex
@@ -1,8 +1,8 @@
-defmodule PhoenixUI.Components.SelectFilter do
+defmodule Phoenix.UI.Components.SelectFilter do
   @moduledoc """
   Provides select filter component.
   """
-  import PhoenixUI.Components.Select
+  import Phoenix.UI.Components.Select
 
   use Phoenix.LiveComponent
 

--- a/lib/phoenix_ui/components/table.ex
+++ b/lib/phoenix_ui/components/table.ex
@@ -1,10 +1,10 @@
-defmodule PhoenixUI.Components.Table do
+defmodule Phoenix.UI.Components.Table do
   @moduledoc """
   Provides a table components.
   """
-  import PhoenixUI.Components.Paper
+  import Phoenix.UI.Components.Paper
 
-  use PhoenixUI, :component
+  use Phoenix.UI, :component
 
   @doc """
   Renders table component.

--- a/lib/phoenix_ui/components/text_filter.ex
+++ b/lib/phoenix_ui/components/text_filter.ex
@@ -1,10 +1,10 @@
-defmodule PhoenixUI.Components.TextFilter do
+defmodule Phoenix.UI.Components.TextFilter do
   @moduledoc """
   Provides text filter component.
   """
-  import PhoenixUI.Components.TextInput
+  import Phoenix.UI.Components.TextInput
 
-  use PhoenixUI, :live_component
+  use Phoenix.UI, :live_component
 
   @default_debounce 300
   @default_end_icon "x"

--- a/lib/phoenix_ui/components/text_input.ex
+++ b/lib/phoenix_ui/components/text_input.ex
@@ -1,11 +1,11 @@
-defmodule PhoenixUI.Components.TextInput do
+defmodule Phoenix.UI.Components.TextInput do
   @moduledoc """
   Provides text input component.
   """
   import Phoenix.HTML.Form, only: [text_input: 3]
-  import PhoenixUI.Components.{ErrorTag, FormGroup, HelperText, Heroicon, Label}
+  import Phoenix.UI.Components.{ErrorTag, FormGroup, HelperText, Heroicon, Label}
 
-  use PhoenixUI, :component
+  use Phoenix.UI, :component
 
   @default_full_width false
   @default_icon_color "inherit"

--- a/lib/phoenix_ui/components/textarea.ex
+++ b/lib/phoenix_ui/components/textarea.ex
@@ -1,11 +1,11 @@
-defmodule PhoenixUI.Components.Textarea do
+defmodule Phoenix.UI.Components.Textarea do
   @moduledoc """
   Provides textarea component.
   """
   import Phoenix.HTML.Form, only: [textarea: 3]
-  import PhoenixUI.Components.{ErrorTag, FormGroup, HelperText, Heroicon, Label}
+  import Phoenix.UI.Components.{ErrorTag, FormGroup, HelperText, Heroicon, Label}
 
-  use PhoenixUI, :component
+  use Phoenix.UI, :component
 
   @default_full_width false
   @default_phx_debounce "blur"

--- a/lib/phoenix_ui/components/tooltip.ex
+++ b/lib/phoenix_ui/components/tooltip.ex
@@ -43,38 +43,6 @@ defmodule PhoenixUI.Components.Tooltip do
     """
   end
 
-  @doc """
-  Returns all possible component classes for Tailwind CSS JIT compilation.
-
-  ## Examples
-
-      iex> classes()
-      ["class1", "class2", ...]
-
-  """
-  @spec classes :: [String.t()]
-  def classes do
-    generate_all_classes(&tooltip/1,
-      color: Theme.colors(),
-      content: [""],
-      position: [
-        "bottom_end",
-        "bottom_start",
-        "bottom",
-        "left_end",
-        "left_start",
-        "left",
-        "right_end",
-        "right_start",
-        "right",
-        "top_end",
-        "top_start",
-        "top"
-      ],
-      variant: ["arrow", "simple"]
-    )
-  end
-
   ### Tooltip Attrs ##########################
 
   defp build_tooltip_attrs(assigns) do

--- a/lib/phoenix_ui/components/tooltip.ex
+++ b/lib/phoenix_ui/components/tooltip.ex
@@ -1,8 +1,8 @@
-defmodule PhoenixUI.Components.Tooltip do
+defmodule Phoenix.UI.Components.Tooltip do
   @moduledoc """
   Provides tooltip component.
   """
-  use PhoenixUI, :component
+  use Phoenix.UI, :component
 
   @default_color "slate"
   @default_position "top"

--- a/lib/phoenix_ui/components/typography.ex
+++ b/lib/phoenix_ui/components/typography.ex
@@ -40,24 +40,6 @@ defmodule PhoenixUI.Components.Typography do
     """
   end
 
-  @doc """
-  Returns all possible component classes for Tailwind CSS JIT compilation.
-
-  ## Examples
-
-      iex> classes()
-      ["class1", "class2", ...]
-
-  """
-  @spec classes :: [String.t()]
-  def classes do
-    generate_all_classes(&typography/1,
-      align: ["center", "justify", "left", "right"],
-      color: Theme.colors(),
-      variant: ["h1", "h2", "h3", "h4", "p"]
-    )
-  end
-
   ### CSS Classes ##########################
 
   # Align

--- a/lib/phoenix_ui/components/typography.ex
+++ b/lib/phoenix_ui/components/typography.ex
@@ -1,8 +1,8 @@
-defmodule PhoenixUI.Components.Typography do
+defmodule Phoenix.UI.Components.Typography do
   @moduledoc """
   Provides typography component.
   """
-  use PhoenixUI, :component
+  use Phoenix.UI, :component
 
   attr(:color, :string, default: "slate")
   attr(:variant, :string, default: "p")

--- a/lib/phoenix_ui/helpers.ex
+++ b/lib/phoenix_ui/helpers.ex
@@ -1,4 +1,4 @@
-defmodule PhoenixUI.Helpers do
+defmodule Phoenix.UI.Helpers do
   @moduledoc """
   Provides helper functionality.
   """

--- a/lib/phoenix_ui/helpers.ex
+++ b/lib/phoenix_ui/helpers.ex
@@ -4,7 +4,7 @@ defmodule PhoenixUI.Helpers do
   """
   alias Phoenix.{HTML.Form, LiveView.Socket}
 
-  import Phoenix.{Component, LiveViewTest}
+  import Phoenix.Component
 
   @doc """
   Builds and normalizes list of classes.
@@ -80,71 +80,6 @@ defmodule PhoenixUI.Helpers do
   """
   @spec build_class([String.t()]) :: String.t()
   def build_class(class_list), do: class_list |> Enum.join(" ") |> String.trim()
-
-  @doc """
-  Generates all possible component assigns permutations, renders ever possible
-  component, scrapes, and returns a list of all possible classnames.
-
-  ## Examples
-
-      ["class1", "class2", ...]
-
-  """
-  @spec generate_all_classes(fun(), Keyword.t()) :: [String.t()]
-  def generate_all_classes(component, attr_permutations) do
-    attr_permutations
-    |> Keyword.put_new(:inner_block, [[]])
-    |> Enum.map(fn {prop, opts} ->
-      Enum.map(opts, fn opt -> Map.put(%{}, prop, opt) end)
-    end)
-    |> Enum.reduce(nil, &permutation/2)
-    |> Enum.map(&extract_classes(&1, component))
-    |> List.flatten()
-    |> Enum.uniq()
-    |> Enum.sort()
-  end
-
-  defp permutation(set1, nil), do: set1
-
-  defp permutation(set1, set2) do
-    Enum.reduce(set1, [], fn item1, acc ->
-      Enum.reduce(set2, acc, fn item2, acc ->
-        [Map.merge(item1, item2) | acc]
-      end)
-    end)
-  end
-
-  defp extract_classes(assigns, component) do
-    html = render_component(component, assigns)
-
-    ~r/(?<=class=\").*?(?=\")/
-    |> Regex.scan(html)
-    |> List.flatten()
-    |> Enum.map(&String.split/1)
-  end
-
-  @doc """
-  Range function that accepts float type parameters.
-
-  ## Examples
-
-      iex> range(0, 2, 0.5)
-      [0, 0.5, 1, 1.5, 2]
-
-  """
-  @spec range(number(), number(), number()) :: [number()]
-  def range(first, last, step \\ 1), do: apply_range([truncate(first)], last, step)
-
-  defp apply_range([current | _] = acc, last, step) when current < last do
-    apply_range([truncate(current + step) | acc], last, step)
-  end
-
-  defp apply_range(acc, _last, _step), do: Enum.reverse(acc)
-
-  defp truncate(val) do
-    truncated = trunc(val)
-    if val - truncated != 0, do: val, else: truncated
-  end
 
   @doc """
   Returns true if assigns field form data has error.

--- a/lib/phoenix_ui/tailwind/generated_classes.ex
+++ b/lib/phoenix_ui/tailwind/generated_classes.ex
@@ -1,6 +1,6 @@
-defmodule PhoenixUI.Tailwind.GeneratedClasses do
+defmodule Phoenix.UI.Tailwind.GeneratedClasses do
   @moduledoc """
-  Referential PhoenixUI classes for JIT compilation:
+  Referential Phoenix.UI classes for JIT compilation:
   - -ml-0.5
   - -ml-1
   - -ml-1.5

--- a/lib/phoenix_ui/tailwind/tailwind.ex
+++ b/lib/phoenix_ui/tailwind/tailwind.ex
@@ -1,4 +1,4 @@
-defmodule PhoenixUI.Tailwind do
+defmodule Phoenix.UI.Tailwind do
   @moduledoc """
   Defaults for each service
   """

--- a/lib/phoenix_ui/theme.ex
+++ b/lib/phoenix_ui/theme.ex
@@ -1,13 +1,13 @@
-defmodule PhoenixUI.Theme do
+defmodule Phoenix.UI.Theme do
   @moduledoc """
   Phoenix UI theme functionality.
   """
-  alias PhoenixUI.Tailwind
+  alias Phoenix.UI.Tailwind
 
   @additional_colors ["danger", "error", "primary", "secondary", "success", "warning", "info"]
 
   @doc """
-  Returns a list of supported PhoenixUI colors.
+  Returns a list of supported Phoenix.UI colors.
 
   ## Examples
 
@@ -19,7 +19,7 @@ defmodule PhoenixUI.Theme do
   def colors, do: Tailwind.colors() ++ @additional_colors
 
   @doc """
-  Returns a list of supported PhoenixUI widths.
+  Returns a list of supported Phoenix.UI widths.
 
   ## Examples
 
@@ -31,7 +31,7 @@ defmodule PhoenixUI.Theme do
   def max_widths, do: Tailwind.max_widths()
 
   @doc """
-  Returns a list of supported PhoenixUI transition durations.
+  Returns a list of supported Phoenix.UI transition durations.
 
   ## Examples
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,4 +1,4 @@
-defmodule PhoenixUI.MixProject do
+defmodule Phoenix.UI.MixProject do
   use Mix.Project
 
   @version "0.1.1"
@@ -60,7 +60,7 @@ defmodule PhoenixUI.MixProject do
   defp docs do
     [
       extras: ["README.md"],
-      main: "PhoenixUI",
+      main: "Phoenix.UI",
       source_ref: "v#{@version}",
       source_url: "https://github.com/keatz55/phoenix_ui"
     ]

--- a/test/phoenix_ui/components/accordion_test.exs
+++ b/test/phoenix_ui/components/accordion_test.exs
@@ -1,6 +1,4 @@
 defmodule PhoenixUI.Components.AccordionTest do
-  alias PhoenixUI.Components.Accordion
-
   use PhoenixUI.Case, async: true
 
   setup do
@@ -27,12 +25,6 @@ defmodule PhoenixUI.Components.AccordionTest do
       assert html =~ "Header"
       assert html =~ "<div class=\"collapse"
       assert html =~ "Content"
-    end
-  end
-
-  describe "classes/0" do
-    test "should generate a list of all possible classes for Tailwind CSS JIT compiler" do
-      assert [_ | _] = Accordion.classes()
     end
   end
 end

--- a/test/phoenix_ui/components/accordion_test.exs
+++ b/test/phoenix_ui/components/accordion_test.exs
@@ -1,5 +1,5 @@
-defmodule PhoenixUI.Components.AccordionTest do
-  use PhoenixUI.Case, async: true
+defmodule Phoenix.UI.Components.AccordionTest do
+  use Phoenix.UI.Case, async: true
 
   setup do
     [assigns: %{}]

--- a/test/phoenix_ui/components/alert_test.exs
+++ b/test/phoenix_ui/components/alert_test.exs
@@ -1,5 +1,5 @@
-defmodule PhoenixUI.Components.AlertTest do
-  use PhoenixUI.Case, async: true
+defmodule Phoenix.UI.Components.AlertTest do
+  use Phoenix.UI.Case, async: true
 
   setup do
     [assigns: %{}]

--- a/test/phoenix_ui/components/alert_test.exs
+++ b/test/phoenix_ui/components/alert_test.exs
@@ -1,6 +1,4 @@
 defmodule PhoenixUI.Components.AlertTest do
-  alias PhoenixUI.Components.Alert
-
   use PhoenixUI.Case, async: true
 
   setup do
@@ -20,12 +18,6 @@ defmodule PhoenixUI.Components.AlertTest do
       assert html =~ "<div role=\"alert\" class=\"alert "
       assert html =~ "<svg class=\"heroicon "
       assert html =~ "Content"
-    end
-  end
-
-  describe "classes/0" do
-    test "should generate a list of all possible classes for Tailwind CSS JIT compiler" do
-      assert [_ | _] = Alert.classes()
     end
   end
 end

--- a/test/phoenix_ui/components/avatar_group_test.exs
+++ b/test/phoenix_ui/components/avatar_group_test.exs
@@ -1,6 +1,4 @@
 defmodule PhoenixUI.Components.AvatarGroupTest do
-  alias PhoenixUI.Components.AvatarGroup
-
   use PhoenixUI.Case, async: true
 
   setup do
@@ -21,12 +19,6 @@ defmodule PhoenixUI.Components.AvatarGroupTest do
       assert html =~ "<div class=\"avatar-group "
       assert html =~ "<div class=\"avatar "
       assert html =~ "<svg class=\"heroicon "
-    end
-  end
-
-  describe "classes/0" do
-    test "should generate a list of all possible classes for Tailwind CSS JIT compiler" do
-      assert [_ | _] = AvatarGroup.classes()
     end
   end
 end

--- a/test/phoenix_ui/components/avatar_group_test.exs
+++ b/test/phoenix_ui/components/avatar_group_test.exs
@@ -1,5 +1,5 @@
-defmodule PhoenixUI.Components.AvatarGroupTest do
-  use PhoenixUI.Case, async: true
+defmodule Phoenix.UI.Components.AvatarGroupTest do
+  use Phoenix.UI.Case, async: true
 
   setup do
     [assigns: %{}]

--- a/test/phoenix_ui/components/avatar_test.exs
+++ b/test/phoenix_ui/components/avatar_test.exs
@@ -1,5 +1,5 @@
-defmodule PhoenixUI.Components.AvatarTest do
-  use PhoenixUI.Case, async: true
+defmodule Phoenix.UI.Components.AvatarTest do
+  use Phoenix.UI.Case, async: true
 
   setup do
     [assigns: %{}]

--- a/test/phoenix_ui/components/avatar_test.exs
+++ b/test/phoenix_ui/components/avatar_test.exs
@@ -1,6 +1,4 @@
 defmodule PhoenixUI.Components.AvatarTest do
-  alias PhoenixUI.Components.Avatar
-
   use PhoenixUI.Case, async: true
 
   setup do
@@ -17,12 +15,6 @@ defmodule PhoenixUI.Components.AvatarTest do
 
       assert html =~ "<div class=\"avatar "
       assert html =~ "<svg class=\"heroicon "
-    end
-  end
-
-  describe "classes/0" do
-    test "should generate a list of all possible classes for Tailwind CSS JIT compiler" do
-      assert [_ | _] = Avatar.classes()
     end
   end
 end

--- a/test/phoenix_ui/components/backdrop_test.exs
+++ b/test/phoenix_ui/components/backdrop_test.exs
@@ -1,6 +1,4 @@
 defmodule PhoenixUI.Components.BackdropTest do
-  alias PhoenixUI.Components.Backdrop
-
   use PhoenixUI.Case, async: true
 
   setup do
@@ -16,12 +14,6 @@ defmodule PhoenixUI.Components.BackdropTest do
       html = rendered_to_string(markup)
 
       assert html =~ "<div class=\"backdrop "
-    end
-  end
-
-  describe "classes/0" do
-    test "should generate a list of all possible classes for Tailwind CSS JIT compiler" do
-      assert [_ | _] = Backdrop.classes()
     end
   end
 end

--- a/test/phoenix_ui/components/backdrop_test.exs
+++ b/test/phoenix_ui/components/backdrop_test.exs
@@ -1,5 +1,5 @@
-defmodule PhoenixUI.Components.BackdropTest do
-  use PhoenixUI.Case, async: true
+defmodule Phoenix.UI.Components.BackdropTest do
+  use Phoenix.UI.Case, async: true
 
   setup do
     [assigns: %{}]

--- a/test/phoenix_ui/components/badge_test.exs
+++ b/test/phoenix_ui/components/badge_test.exs
@@ -1,6 +1,4 @@
 defmodule PhoenixUI.Components.BadgeTest do
-  alias PhoenixUI.Components.Badge
-
   use PhoenixUI.Case, async: true
 
   setup do
@@ -20,12 +18,6 @@ defmodule PhoenixUI.Components.BadgeTest do
       assert html =~ "<div class=\"badge-wrapper "
       assert html =~ "<div class=\"badge "
       assert html =~ "99+"
-    end
-  end
-
-  describe "classes/0" do
-    test "should generate a list of all possible classes for Tailwind CSS JIT compiler" do
-      assert [_ | _] = Badge.classes()
     end
   end
 end

--- a/test/phoenix_ui/components/badge_test.exs
+++ b/test/phoenix_ui/components/badge_test.exs
@@ -1,5 +1,5 @@
-defmodule PhoenixUI.Components.BadgeTest do
-  use PhoenixUI.Case, async: true
+defmodule Phoenix.UI.Components.BadgeTest do
+  use Phoenix.UI.Case, async: true
 
   setup do
     [assigns: %{}]

--- a/test/phoenix_ui/components/button_test.exs
+++ b/test/phoenix_ui/components/button_test.exs
@@ -1,5 +1,5 @@
-defmodule PhoenixUI.Components.ButtonTest do
-  use PhoenixUI.Case, async: true
+defmodule Phoenix.UI.Components.ButtonTest do
+  use Phoenix.UI.Case, async: true
 
   setup do
     [assigns: %{text: "text"}]

--- a/test/phoenix_ui/components/button_test.exs
+++ b/test/phoenix_ui/components/button_test.exs
@@ -1,6 +1,4 @@
 defmodule PhoenixUI.Components.ButtonTest do
-  alias PhoenixUI.Components.Button
-
   use PhoenixUI.Case, async: true
 
   setup do
@@ -21,12 +19,6 @@ defmodule PhoenixUI.Components.ButtonTest do
       assert html =~ "type=\"button\">"
       assert html =~ assigns.text
       assert html =~ "</button>"
-    end
-  end
-
-  describe "classes/0" do
-    test "should generate a list of all possible classes for Tailwind CSS JIT compiler" do
-      assert [_ | _] = Button.classes()
     end
   end
 end

--- a/test/phoenix_ui/components/divider_test.exs
+++ b/test/phoenix_ui/components/divider_test.exs
@@ -1,5 +1,5 @@
-defmodule PhoenixUI.Components.DividerTest do
-  use PhoenixUI.Case, async: true
+defmodule Phoenix.UI.Components.DividerTest do
+  use Phoenix.UI.Case, async: true
 
   setup do
     [assigns: %{}]

--- a/test/phoenix_ui/components/divider_test.exs
+++ b/test/phoenix_ui/components/divider_test.exs
@@ -1,6 +1,4 @@
 defmodule PhoenixUI.Components.DividerTest do
-  alias PhoenixUI.Components.Divider
-
   use PhoenixUI.Case, async: true
 
   setup do
@@ -16,12 +14,6 @@ defmodule PhoenixUI.Components.DividerTest do
       html = rendered_to_string(markup)
 
       assert html =~ "<hr class=\"divider "
-    end
-  end
-
-  describe "classes/0" do
-    test "should generate a list of all possible classes for Tailwind CSS JIT compiler" do
-      assert [_ | _] = Divider.classes()
     end
   end
 end

--- a/test/phoenix_ui/components/grid_test.exs
+++ b/test/phoenix_ui/components/grid_test.exs
@@ -1,6 +1,4 @@
 defmodule PhoenixUI.Components.GridTest do
-  alias PhoenixUI.Components.Grid
-
   use PhoenixUI.Case, async: true
 
   setup do
@@ -19,12 +17,6 @@ defmodule PhoenixUI.Components.GridTest do
 
       assert html =~ "<div class=\"grid "
       assert html =~ assigns[:text]
-    end
-  end
-
-  describe "classes/0" do
-    test "should generate a list of all possible classes for Tailwind CSS JIT compiler" do
-      assert [_ | _] = Grid.classes()
     end
   end
 end

--- a/test/phoenix_ui/components/grid_test.exs
+++ b/test/phoenix_ui/components/grid_test.exs
@@ -1,5 +1,5 @@
-defmodule PhoenixUI.Components.GridTest do
-  use PhoenixUI.Case, async: true
+defmodule Phoenix.UI.Components.GridTest do
+  use Phoenix.UI.Case, async: true
 
   setup do
     [assigns: %{text: "text"}]

--- a/test/phoenix_ui/components/heroicon_test.exs
+++ b/test/phoenix_ui/components/heroicon_test.exs
@@ -1,6 +1,4 @@
 defmodule PhoenixUI.Components.HeroiconTest do
-  alias PhoenixUI.Components.Heroicon
-
   use PhoenixUI.Case, async: true
 
   setup do
@@ -16,12 +14,6 @@ defmodule PhoenixUI.Components.HeroiconTest do
       html = rendered_to_string(markup)
 
       assert html =~ "<svg class=\"heroicon "
-    end
-  end
-
-  describe "classes/0" do
-    test "should generate a list of all possible classes for Tailwind CSS JIT compiler" do
-      assert [_ | _] = Heroicon.classes()
     end
   end
 end

--- a/test/phoenix_ui/components/heroicon_test.exs
+++ b/test/phoenix_ui/components/heroicon_test.exs
@@ -1,5 +1,5 @@
-defmodule PhoenixUI.Components.HeroiconTest do
-  use PhoenixUI.Case, async: true
+defmodule Phoenix.UI.Components.HeroiconTest do
+  use Phoenix.UI.Case, async: true
 
   setup do
     [assigns: %{}]

--- a/test/phoenix_ui/components/link_test.exs
+++ b/test/phoenix_ui/components/link_test.exs
@@ -1,5 +1,5 @@
-defmodule PhoenixUI.Components.LinkTest do
-  use PhoenixUI.Case, async: true
+defmodule Phoenix.UI.Components.LinkTest do
+  use Phoenix.UI.Case, async: true
 
   setup do
     [assigns: %{text: "text"}]

--- a/test/phoenix_ui/components/link_test.exs
+++ b/test/phoenix_ui/components/link_test.exs
@@ -1,6 +1,4 @@
 defmodule PhoenixUI.Components.LinkTest do
-  alias PhoenixUI.Components.Link
-
   use PhoenixUI.Case, async: true
 
   setup do
@@ -21,12 +19,6 @@ defmodule PhoenixUI.Components.LinkTest do
       assert html =~ "class=\"link "
       assert html =~ assigns.text
       assert html =~ "</a>"
-    end
-  end
-
-  describe "classes/0" do
-    test "should generate a list of all possible classes for Tailwind CSS JIT compiler" do
-      assert [_ | _] = Link.classes()
     end
   end
 end

--- a/test/phoenix_ui/components/typography_test.exs
+++ b/test/phoenix_ui/components/typography_test.exs
@@ -1,6 +1,4 @@
 defmodule PhoenixUI.Components.TypographyTest do
-  alias PhoenixUI.Components.Typography
-
   use PhoenixUI.Case, async: true
 
   setup do
@@ -20,12 +18,6 @@ defmodule PhoenixUI.Components.TypographyTest do
       assert html =~ "<p class=\"typography "
       assert html =~ assigns.text
       assert html =~ "</p>"
-    end
-  end
-
-  describe "classes/0" do
-    test "should generate a list of all possible classes for Tailwind CSS JIT compiler" do
-      assert [_ | _] = Typography.classes()
     end
   end
 end

--- a/test/phoenix_ui/components/typography_test.exs
+++ b/test/phoenix_ui/components/typography_test.exs
@@ -1,5 +1,5 @@
-defmodule PhoenixUI.Components.TypographyTest do
-  use PhoenixUI.Case, async: true
+defmodule Phoenix.UI.Components.TypographyTest do
+  use Phoenix.UI.Case, async: true
 
   setup do
     [assigns: %{text: "text"}]

--- a/test/support/case.ex
+++ b/test/support/case.ex
@@ -1,11 +1,11 @@
-defmodule PhoenixUI.Case do
+defmodule Phoenix.UI.Case do
   @moduledoc false
   use ExUnit.CaseTemplate
 
   using do
     quote do
       use Phoenix.Component
-      use PhoenixUI
+      use Phoenix.UI
 
       import Phoenix.LiveViewTest
 


### PR DESCRIPTION
Makes the following updates:
- consolidates component-specific class generation for tailwind jit compiler to a single mix task
- renames `PhoenixUI` to `Phoenix.UI` for easier integration w/ `Phoenix` module namespace